### PR TITLE
doc(google ads): Fix relative links in Google Ads transform README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This package contains transformation models, designed to work simultaneously wit
 
 | **model**                       | **description** |**compatible API**                                                                                                                   |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |------------------------------- | 
-| [google_ads__url_ad_adapter](models/url_google_ads/google_ads__url_ad_adapter.sql)      | Each record represents the daily ad performance of each URL in each ad group, including information about the used UTM parameters. | Adwords API and Google Ads API |
-| [google_ads__criteria_ad_adapter](models/criteria/google_ads__criteria_ad_adapter.sql) | Each record represents the daily ad performance of each criteria in each ad group.                                                 | Adwords API Only|
-| [google_ads__click_performance](models/google_ads__click_performance.sql)   | Each record represents a click, with a corresponding Google click ID (gclid).                                                      | Adwords API Only |
+| [google_ads__url_ad_adapter](https://github.com/fivetran/dbt_google_ads/blob/main/models/url_google_ads/google_ads__url_ad_adapter.sql)      | Each record represents the daily ad performance of each URL in each ad group, including information about the used UTM parameters. | Adwords API and Google Ads API |
+| [google_ads__criteria_ad_adapter](https://github.com/fivetran/dbt_google_ads/blob/main/models/criteria/google_ads__criteria_ad_adapter.sql) | Each record represents the daily ad performance of each criteria in each ad group.                                                 | Adwords API Only|
+| [google_ads__click_performance](https://github.com/fivetran/dbt_google_ads/blob/main/models/google_ads__click_performance.sql)   | Each record represents a click, with a corresponding Google click ID (gclid).                                                      | Adwords API Only |
 
 ## Installation Instructions
 Check [dbt Hub](https://hub.getdbt.com/) for the latest installation instructions, or [read the dbt docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.


### PR DESCRIPTION
Closes https://fivetran.height.app/T-228326

Replaces relative links with absolute links that do not break when rendered in our docs.

